### PR TITLE
Google OAuth requirements

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -43,7 +43,7 @@ private
 
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :zip, :latitude, :longitude)
+    params.permit(:name, :email, :password, :password_confirmation, :zip, :latitude, :longitude)
   end
 
   def not_found

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,7 @@ class User < ApplicationRecord
   has_many :user_plants
   has_many :plants, through: :user_plants
 
-  validates :name, :email, :password_digest, presence: true
+  validates :name, :email, presence: true
   validates :email, uniqueness: true
 
-  has_secure_password
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
     email { "#{name.downcase.gsub(/ /, '_')}@email.com" }
-    password { 'password123' }
-    password_confirmation { 'password123' }
+    # password { 'password123' }
+    # password_confirmation { 'password123' }
     zip { '80918' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,15 +10,5 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email) }
-    it { should validate_presence_of(:password_digest) }
-    it { should have_secure_password }
-  end
-
-  describe 'secure user creation' do
-    it 'saves user auth info securely' do
-      user = User.create(name: 'Jeff', email: 'jeff@email.com', password: 'password123', password_confirmation: 'password123', zip: '80918')
-      expect(user).to_not have_attribute(:password)
-      expect(user.password_digest).to_not eq('password123')
-    end
   end
 end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Users API endpoints' do
     before(:each) do
       user1 = create(:user)
       @previous_name = user1.name
-      patch "/api/v1/users/#{user1.id}", params: { user: { name: 'Jenna' } }
+      patch "/api/v1/users/#{user1.id}", params: { name: 'Jenna' }
     end
     let!(:user1) { JSON.parse(response.body, symbolize_names: true) }
 
@@ -113,14 +113,14 @@ RSpec.describe 'Users API endpoints' do
     end
 
     it 'returns status 404 if user not found' do
-      patch '/api/v1/users/6514980891', params: { user: { name: 'Jenna' } }
+      patch '/api/v1/users/6514980891', params:  { name: 'Jenna' }
 
       expect(response.status).to eq(404)
     end
 
     it 'updates the users zip code and coordinates' do
       user = create(:user)
-      patch "/api/v1/users/#{user.id}", params: { user: { zip: '80223' } }
+      patch "/api/v1/users/#{user.id}", params:  { zip: '80223' }
       updated_user = JSON.parse(response.body, symbolize_names: true)
 
       expect(updated_user[:data][:attributes][:zip]).to eq("80223")
@@ -132,7 +132,7 @@ RSpec.describe 'Users API endpoints' do
 
   describe 'POST user' do
     it 'can create new user' do
-      user_params = { user: { name: 'Jeff', email: 'jeff@email.com', password: 'password123', password_confirmation: 'password123', zip: '80918' } }
+      user_params = { name: 'Jeff', email: 'jeff@email.com', zip: '80918' } 
       post '/api/v1/users', params: user_params
       created_user = User.last
 


### PR DESCRIPTION
In order to allow for OAuth to create users, the password validations needed to be dropped as well as the require user params because we aren't using a form to create a user through google.